### PR TITLE
[bug] Mobs are now visible

### DIFF
--- a/Net/Handlers/MapObjectHandlers.cpp
+++ b/Net/Handlers/MapObjectHandlers.cpp
@@ -203,7 +203,7 @@ namespace ms
 		recv.read_byte(); // 5 if controller == null
 		int32_t id = recv.read_int();
 
-		recv.skip(22);
+		recv.skip(16);
 
 		Point<int16_t> position = recv.read_point();
 		int8_t stance = recv.read_byte();


### PR DESCRIPTION
## Description

Noticed from client debug that on SPAWN_MOB(237) packet, stack underflow was occurring. 

The server sends a packet length of 42, so this change reflects this.

## Test Plan

Booted server and client. After this change, the GUI was able to display mobs.